### PR TITLE
Fix closing of multiline comment blocks

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -94,7 +94,7 @@ export function transformComment(comment: string | StringValueNode, indentLevel 
         return indent(`/** ${comment} */\n`, indentLevel);
       }
 
-      return indent(`${isFirst ? '/** \n' : ''} * ${line}${isLast ? '\n **/\n' : ''}`, indentLevel);
+      return indent(`${isFirst ? '/** \n' : ''} * ${line}${isLast ? '\n */\n' : ''}`, indentLevel);
     })
     .join('\n');
 }


### PR DESCRIPTION
Now it's impossible to fix `**/` multiline comment ending to be them linted correctly